### PR TITLE
Add list of TUF implementations

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -1,0 +1,23 @@
+# TUF implementations
+
+We list open source implementations of TUF in several languages, along with links to project code and documentation. This list is not an endorsement of any project, but rather a resource for interested users and contributors. If there is an implementation or piece of documentation missing from this list, please open a pr on this repository to update it.
+
+## python-tuf
+
+* [source code](https://github.com/theupdateframework/python-tuf)
+
+## go-tuf
+
+* [source code](https://github.com/theupdateframework/go-tuf)
+
+## rust-tuf
+
+* [source code](https://github.com/theupdateframework/rust-tuf)
+
+## tough
+
+* [source code](https://github.com/awslabs/tough)
+
+## php-tuf
+
+* [source code](https://github.com/php-tuf/php-tuf)


### PR DESCRIPTION
This list is intended to supersede the roadmap section proposed in #theupdateframework/specification#284. For now it just lists implementations, but can be extended to link to roadmaps (once they exist for projects) and other documentation